### PR TITLE
Align expense and planner pages with reference modules

### DIFF
--- a/src/pages/AnnualExpensesPage.js
+++ b/src/pages/AnnualExpensesPage.js
@@ -248,7 +248,7 @@ const AnnualExpensesPage = () => {
             </div>
           </Card>
 
-          <Card title="Monthly Savings Needed" className="summary-card">
+          <Card title="Monthly Savings Plan" className="summary-card">
             <div className="summary-amount info">
               {formatCurrency(Object.values(accountSavingsPlan).reduce((total, amount) => total + amount, 0))}
             </div>

--- a/src/pages/MonthlyExpensesPage.js
+++ b/src/pages/MonthlyExpensesPage.js
@@ -3,10 +3,9 @@ import React, { useState } from 'react';
 import { useBudget } from '../context/BudgetContext';
 import Card from '../components/ui/Card';
 import Button from '../components/ui/Button';
-import CategoryManager from '../components/CategoryManager';
 import ExpenseItem from '../components/ExpenseItem';
 import { EXPENSE_CATEGORIES, DEFAULT_ACCOUNTS } from '../utils/constants';
-import { formatCurrency, parseAmount } from '../utils/formatters';
+import { parseAmount } from '../utils/formatters';
 
 const MonthlyExpensesPage = () => {
   const { state, actions, calculations, formatCurrency: formatCurrencyUtil } = useBudget();
@@ -182,7 +181,7 @@ const MonthlyExpensesPage = () => {
       {/* Summary Cards */}
       <div className="summary-section">
         <div className="summary-grid">
-          <Card title="Monthly Expenses Total" className="summary-card">
+          <Card title="Total Monthly Expenses" className="summary-card">
             <div className="summary-amount expense">
               {formatCurrencyUtil(totalMonthlyExpenses)}
             </div>
@@ -191,7 +190,7 @@ const MonthlyExpensesPage = () => {
             </div>
           </Card>
 
-          <Card title="Account Allocation" className="summary-card">
+          <Card title="Funds to Set Aside by Account" className="summary-card">
             <div className="account-breakdown">
               {Object.entries(accountSummary).map(([account, total]) => (
                 <div key={account} className="account-item">

--- a/src/pages/WeeklyPlannerPage.js
+++ b/src/pages/WeeklyPlannerPage.js
@@ -261,7 +261,7 @@ const WeeklyPlannerPage = () => {
             </div>
           </Card>
 
-          <Card title="Net Weekly Flow" className="summary-card">
+          <Card title="Net Weekly Flow (Surplus/Deficit)" className="summary-card">
             <div className={`summary-amount ${getNetWeeklyFlow() >= 0 ? 'positive' : 'negative'}`}>
               {formatCurrency(getNetWeeklyFlow())}
             </div>


### PR DESCRIPTION
## Summary
- Bring Monthly Expenses page in line with reference module, removing unused imports and renaming summary cards for total expenses and account-based funds.
- Rename Annual Expenses summary card to "Monthly Savings Plan" to match reference behavior.
- Update Weekly Planner summary card title to clearly denote net flow surplus or deficit.

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68928bad072c83309fadfe760263a5c1