### PR TITLE
Allow decimals in quick entry amounts

### DIFF
--- a/src/components/QuickEntrySection.js
+++ b/src/components/QuickEntrySection.js
@@ -104,7 +104,7 @@ const QuickEntrySection = ({
                       <input
                         type="text"
                         inputMode="decimal"
-                        pattern="[0-9]*[.,]?[0-9]*"
+                        pattern="[-0-9.,]*"
                         autoComplete="off"
                         className={`quick-entry-amount-input ${
                           income.payActuals?.[index] !== undefined &&

--- a/src/pages/IncomePage.js
+++ b/src/pages/IncomePage.js
@@ -426,11 +426,16 @@ const IncomePage = () => {
       sanitized = sanitized.replace(/[.,]/g, '');
     }
 
+    const hasTrailingDecimal = sanitized.endsWith('.');
     const parts = sanitized.split('.');
     const intPart = parts[0] || '';
     const decPart = parts[1] ? parts[1].slice(0, 2) : '';
     let result = intPart;
-    if (decPart) result += '.' + decPart;
+    if (decPart) {
+      result += '.' + decPart;
+    } else if (hasTrailingDecimal) {
+      result += '.';
+    }
     return negative && result ? '-' + result : result;
   };
 


### PR DESCRIPTION
## Summary
- permit decimal input for quick entry amounts by preserving trailing decimal points
- allow commas and periods in quick entry amount fields to handle values like 1,050.45

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4e8c2c66083309d63bdce43c88fe1