### PR TITLE
Improve planner usability and status aggregation

### DIFF
--- a/src/context/BudgetContext.js
+++ b/src/context/BudgetContext.js
@@ -2,6 +2,7 @@
 import React, { createContext, useContext, useReducer, useEffect } from 'react';
 import { createDefaultData } from '../utils/validators';
 import { formatCurrency, parseAmount } from '../utils/formatters';
+import { ALL_WEEKS } from '../utils/constants';
 
 const BudgetContext = createContext();
 
@@ -50,7 +51,7 @@ const initialState = {
   isLoading: false,
   lastUpdated: new Date().toISOString(),
   plannerState: {},
-  currentWeek: 1,
+  currentWeek: ALL_WEEKS,
   isCalculatorOpen: false // Added calculator state
 };
 
@@ -560,7 +561,11 @@ export function BudgetProvider({ children }) {
           plannerExpense[statusType] = Array(5).fill(false);
         }
         plannerExpense[statusType] = [...plannerExpense[statusType]];
-        plannerExpense[statusType][weekIndex] = checked;
+        if (weekIndex === null || weekIndex === undefined || weekIndex < 0) {
+          plannerExpense[statusType] = plannerExpense[statusType].map(() => checked);
+        } else {
+          plannerExpense[statusType][weekIndex] = checked;
+        }
         updatedPlanner[expenseName] = plannerExpense;
       }
 

--- a/src/pages/AnnualExpensesPage.js
+++ b/src/pages/AnnualExpensesPage.js
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { useBudget } from '../context/BudgetContext';
 import { AnnualExpensesPrint } from '../utils/printUtils';
 import { getStatusAmount } from '../utils/expenseUtils';
+import { ALL_WEEKS } from '../utils/constants';
 
 const ANNUAL_CATEGORY_NAMES = {
   'yearly-subs': 'Yearly Subscriptions',
@@ -17,11 +18,15 @@ const ANNUAL_CATEGORY_NAMES = {
 
 const AnnualExpensesPage = () => {
   const { state, actions, calculations, formatCurrency } = useBudget();
-  const [currentWeek, setCurrentWeek] = useState(1);
+  const [currentWeek, setCurrentWeek] = useState(ALL_WEEKS);
 
   const getPlannerStatus = (expenseName, statusType) => {
     const entry = state.data.plannerState?.[expenseName];
-    return entry?.[statusType]?.[currentWeek - 1] || false;
+    const statuses = entry?.[statusType] || [];
+    if (currentWeek === ALL_WEEKS) {
+      return statuses.some(Boolean);
+    }
+    return statuses[currentWeek - 1] || false;
   };
 
   // Auto-populate planner when annual data changes
@@ -69,10 +74,11 @@ const AnnualExpensesPage = () => {
 
     // Sync with weekly planner for current week
     if (expense.name) {
+      const weekIndex = currentWeek === ALL_WEEKS ? null : currentWeek - 1;
       actions.updateExpenseStatus(
         updatedExpense.id,
         expense.name,
-        currentWeek - 1, // Convert to 0-based index
+        weekIndex,
         statusType,
         checked,
         'annual'
@@ -926,6 +932,7 @@ const AnnualExpensesPage = () => {
           onChange={(e) => setCurrentWeek(parseInt(e.target.value))}
           className="week-select"
         >
+          <option value={ALL_WEEKS}>All Weeks (Month)</option>
           <option value={1}>Week 1</option>
           <option value={2}>Week 2</option>
           <option value={3}>Week 3</option>
@@ -933,7 +940,7 @@ const AnnualExpensesPage = () => {
           <option value={5}>Week 5</option>
         </select>
         <span style={{ fontSize: '0.9rem', color: 'var(--text-secondary)' }}>
-          Status changes will sync with this week in the weekly planner
+          Status changes will sync with {currentWeek === ALL_WEEKS ? 'all weeks' : `Week ${currentWeek}`} in the weekly planner
         </span>
       </div>
 
@@ -1194,7 +1201,7 @@ const AnnualExpensesPage = () => {
         <h4>📊 Weekly Planner Integration</h4>
         <div className="sync-info">
           • Annual expenses automatically populate the weekly planner as monthly equivalents (annual ÷ 12)<br />
-          • Status changes (Paid/Transferred) sync with Week {currentWeek} in the weekly planner<br />
+          • Status changes (Paid/Transferred) sync with {currentWeek === ALL_WEEKS ? 'All Weeks' : `Week ${currentWeek}`} in the weekly planner<br />
           • Due dates determine which week expenses are planned for<br />
           • Changes here update the weekly planner in real-time
         </div>

--- a/src/pages/MonthlyExpensesPage.js
+++ b/src/pages/MonthlyExpensesPage.js
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { useBudget } from '../context/BudgetContext';
 import { MonthlyExpensesPrint } from '../utils/printUtils';
 import { getStatusAmount } from '../utils/expenseUtils';
+import { ALL_WEEKS } from '../utils/constants';
 
 const CATEGORY_NAMES = {
   housing: 'Housing',
@@ -26,11 +27,15 @@ const CATEGORY_NAMES = {
 const MonthlyExpensesPage = () => {
   const { state, actions, calculations, formatCurrency } = useBudget();
   const [showZeroValues, setShowZeroValues] = useState(true);
-  const [currentWeek, setCurrentWeek] = useState(1);
+  const [currentWeek, setCurrentWeek] = useState(ALL_WEEKS);
 
   const getPlannerStatus = (expenseName, statusType) => {
     const entry = state.data.plannerState?.[expenseName];
-    return entry?.[statusType]?.[currentWeek - 1] || false;
+    const statuses = entry?.[statusType] || [];
+    if (currentWeek === ALL_WEEKS) {
+      return statuses.some(Boolean);
+    }
+    return statuses[currentWeek - 1] || false;
   };
 
   // Auto-populate planner when monthly data changes
@@ -77,10 +82,11 @@ const MonthlyExpensesPage = () => {
 
     // Sync with weekly planner for current week
     if (expense.name) {
+      const weekIndex = currentWeek === ALL_WEEKS ? null : currentWeek - 1;
       actions.updateExpenseStatus(
         updatedExpense.id,
         expense.name,
-        currentWeek - 1, // Convert to 0-based index
+        weekIndex,
         statusType,
         checked,
         'monthly'
@@ -840,6 +846,7 @@ const MonthlyExpensesPage = () => {
           onChange={(e) => setCurrentWeek(parseInt(e.target.value))}
           className="week-select"
         >
+          <option value={ALL_WEEKS}>All Weeks (Month)</option>
           <option value={1}>Week 1</option>
           <option value={2}>Week 2</option>
           <option value={3}>Week 3</option>
@@ -847,7 +854,7 @@ const MonthlyExpensesPage = () => {
           <option value={5}>Week 5</option>
         </select>
         <span style={{ fontSize: '0.9rem', color: 'var(--text-secondary)' }}>
-          Status changes will sync with this week in the weekly planner
+          Status changes will sync with {currentWeek === ALL_WEEKS ? 'all weeks' : `Week ${currentWeek}`} in the weekly planner
         </span>
       </div>
 
@@ -1080,7 +1087,7 @@ const MonthlyExpensesPage = () => {
         <h4>📊 Weekly Planner Integration</h4>
         <div className="sync-info">
           • Monthly expenses automatically populate the weekly planner<br />
-          • Status changes (Paid/Transferred) sync with Week {currentWeek} in the weekly planner<br />
+          • Status changes (Paid/Transferred) sync with {currentWeek === ALL_WEEKS ? 'All Weeks' : `Week ${currentWeek}`} in the weekly planner<br />
           • Due dates determine which week expenses are planned for<br />
           • Changes here update the weekly planner in real-time
         </div>

--- a/src/pages/WeeklyPlannerPage.js
+++ b/src/pages/WeeklyPlannerPage.js
@@ -886,6 +886,9 @@ const WeeklyPlannerPage = () => {
           text-align: left;
           width: 240px;
           min-width: 240px;
+          position: sticky;
+          left: 0;
+          z-index: 11;
         }
 
         .planner-table th:nth-child(2) {
@@ -942,8 +945,8 @@ const WeeklyPlannerPage = () => {
         }
 
         .category-row {
-          background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--hover-bg) 100%) !important;
-          font-weight: bold;
+          background: var(--category-section-bg) !important;
+          font-weight: 700;
           color: var(--text-primary);
         }
 
@@ -951,7 +954,7 @@ const WeeklyPlannerPage = () => {
           text-align: left !important;
           padding-left: 15px !important;
           font-size: 0.9rem !important;
-          background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--hover-bg) 100%) !important;
+          background: var(--category-section-bg) !important;
         }
 
         .expense-name {
@@ -961,6 +964,14 @@ const WeeklyPlannerPage = () => {
           color: var(--text-primary);
           width: 240px;
           max-width: 240px;
+          position: sticky;
+          left: 0;
+          z-index: 5;
+          background-color: var(--card-bg);
+        }
+
+        .planner-table tr:hover .expense-name {
+          background-color: var(--hover-bg);
         }
 
         .annual-indicator {

--- a/src/pages/WeeklyPlannerPage.js
+++ b/src/pages/WeeklyPlannerPage.js
@@ -955,6 +955,9 @@ const WeeklyPlannerPage = () => {
           padding-left: 15px !important;
           font-size: 0.9rem !important;
           background: var(--category-section-bg) !important;
+          position: sticky;
+          left: 0;
+          z-index: 6;
         }
 
         .expense-name {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -80,13 +80,21 @@
 }
 
 .month-select {
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.3);
-  color: var(--header-text);
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  color: var(--text-primary);
   padding: 0.25rem 0.5rem;
   border-radius: 0.375rem;
   font-size: 0.75rem;
   min-width: 120px;
+}
+
+.month-select option {
+  color: var(--text-primary);
+}
+
+.month-select:focus {
+  outline: 2px solid var(--input-focus);
 }
 
 .theme-toggle {
@@ -3608,6 +3616,20 @@
   text-align: left;
   width: 240px;
   min-width: 240px;
+  position: sticky;
+  left: 0;
+  z-index: 11;
+}
+
+/* Keep expense names visible when horizontally scrolling */
+.planner-table tr:not(.category-row) td:first-child {
+  text-align: left;
+  width: 240px;
+  min-width: 240px;
+  position: sticky;
+  left: 0;
+  z-index: 5;
+  background: var(--card-bg);
 }
 
 .planner-table th:nth-child(2) {
@@ -3696,8 +3718,8 @@
 }
 
 .category-row {
-  background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--hover-bg) 100%) !important;
-  font-weight: bold;
+  background: var(--category-section-bg) !important;
+  font-weight: 700;
   color: var(--text-primary);
 }
 
@@ -3705,7 +3727,7 @@
   text-align: left !important;
   padding-left: 15px !important;
   font-size: 0.9rem !important;
-  background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--hover-bg) 100%) !important;
+  background: var(--category-section-bg) !important;
 }
 
 .expense-name {
@@ -3715,6 +3737,14 @@
   color: var(--text-primary);
   width: 240px;
   max-width: 240px;
+  position: sticky;
+  left: 0;
+  z-index: 2;
+  background-color: var(--card-bg);
+}
+
+.planner-table tr:hover .expense-name {
+  background-color: var(--hover-bg);
 }
 
 .annual-indicator {

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -3728,6 +3728,9 @@
   padding-left: 15px !important;
   font-size: 0.9rem !important;
   background: var(--category-section-bg) !important;
+  position: sticky;
+  left: 0;
+  z-index: 6;
 }
 
 .expense-name {

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -77,6 +77,8 @@
   --table-header-bg: #34495e;
   --table-header-text: #ffffff;
   --table-row-hover: #f8f9fa;
+  /* Category Section */
+  --category-section-bg: #e6f2ff;
 
   /* Border Colors */
   --border-light: #e9ecef;
@@ -185,6 +187,8 @@
   --table-header-bg: #212529;
   --table-header-text: #ecf0f1;
   --table-row-hover: #3d3d3d;
+  /* Category Section */
+  --category-section-bg: #1f3b57;
 
   /* Border Colors */
   --border-light: #4d4d4d;

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -129,6 +129,9 @@ export const CALCULATION_CONSTANTS = {
   DAYS_PER_YEAR: 365.25
 };
 
+// Week selection
+export const ALL_WEEKS = 0;
+
 // Notification types
 export const NOTIFICATION_TYPES = {
   SUCCESS: 'success',


### PR DESCRIPTION
## Summary
- make weekly planner category column sticky and highlight category sections
- add "All Weeks (Month)" aggregation option in monthly and annual expense views
- fix header month dropdown styling for readable text
- ensure sticky weekly planner column has solid background for clarity
- default monthly and annual week sync to "All Weeks (Month)"

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a5d684ea888330bf40c749deb20ebf